### PR TITLE
fix(trans): fix the msgstr for nn.flatten

### DIFF
--- a/source/locale/zh_CN/LC_MESSAGES/api_zh/megengine.functional.po
+++ b/source/locale/zh_CN/LC_MESSAGES/api_zh/megengine.functional.po
@@ -1243,15 +1243,15 @@ msgstr "单位矩阵"
 msgid ""
 "Reshapes the tensor by flattening the sub-tensor from dimension "
 "``start_axis`` to dimension ``end_axis``."
-msgstr "通过将子张量从 ``start_axis`` 维展平到 ``end_axis`` 维，实现对张量的重塑(reshape)。"
+msgstr "通过将从 ``start_axis`` 维到 ``end_axis`` 维的子张量进行展平，实现对张量的重塑(reshape)。"
 
 #: megengine.functional.nn.flatten:6 of
 msgid "The start dimension that the sub-tensor to be flattened. Default: 0"
-msgstr "子张量被展平时的初始维数。 默认： 0"
+msgstr "需要被展平的子张量的起始维数。 默认： 0"
 
 #: megengine.functional.nn.flatten:8 of
 msgid "The end dimension that the sub-tensor to be flattened. Default: -1"
-msgstr "子张量被展平时的最终维数。 默认： -1"
+msgstr "需要被展平的子张量的最终维数。 默认： -1"
 
 #: megengine.functional.nn.identity:1 of
 msgid "applies an identity transform to the input tensor."

--- a/source/locale/zh_CN/LC_MESSAGES/api_zh/megengine.functional.po
+++ b/source/locale/zh_CN/LC_MESSAGES/api_zh/megengine.functional.po
@@ -1243,7 +1243,7 @@ msgstr "单位矩阵"
 msgid ""
 "Reshapes the tensor by flattening the sub-tensor from dimension "
 "``start_axis`` to dimension ``end_axis``."
-msgstr "通过将从 ``start_axis`` 维到 ``end_axis`` 维的子张量进行展平，实现对张量的重塑(reshape)。"
+msgstr "将张量的 ``start_axis`` 维到 ``end_axis`` 维部分，展平为一维"
 
 #: megengine.functional.nn.flatten:6 of
 msgid "The start dimension that the sub-tensor to be flattened. Default: 0"
@@ -1251,7 +1251,7 @@ msgstr "需要被展平的子张量的起始维数。 默认： 0"
 
 #: megengine.functional.nn.flatten:8 of
 msgid "The end dimension that the sub-tensor to be flattened. Default: -1"
-msgstr "需要被展平的子张量的最终维数。 默认： -1"
+msgstr "需要被展平的子张量的终止维数。 默认： -1"
 
 #: megengine.functional.nn.identity:1 of
 msgid "applies an identity transform to the input tensor."


### PR DESCRIPTION
The original comment: 
**Reshapes the tensor by flattening the sub-tensor from dimension ``start_axis`` to dimension ``end_axis``.**

Fix its Chinese message string according to the example:

```
.. testcode::

        import numpy as np
        from megengine import tensor
        import megengine.functional as F

        inp_shape = (2, 2, 3, 3)
        inp = tensor(
            np.arange(36, dtype=np.int32).reshape(inp_shape),
        )
        oup = F.flatten(inp, 2)
        print(inp.numpy().shape)
        print(oup.numpy().shape)

    Outputs:

    .. testoutput::

        (2, 2, 3, 3)
        (2, 2, 9)
```